### PR TITLE
Johan dev

### DIFF
--- a/ADFSToolkit/Private/Add-ADFSTkSPRelyingPartyTrust.ps1
+++ b/ADFSToolkit/Private/Add-ADFSTkSPRelyingPartyTrust.ps1
@@ -120,7 +120,9 @@ function Add-ADFSTkSPRelyingPartyTrust {
         Write-ADFSTkVerboseLog "Added Forced Entity Categories: $($ForcedEntityCategories -join ',')"
     }
 
-    $IssuanceTransformRules = Get-ADFSTkIssuanceTransformRules $EntityCategories -EntityId $entityID -RequestedAttribute $sp.SPSSODescriptor.AttributeConsumingService.RequestedAttribute
+    $IssuanceTransformRules = Get-ADFSTkIssuanceTransformRules $EntityCategories -EntityId $entityID `
+                                                                                 -RequestedAttribute $sp.SPSSODescriptor.AttributeConsumingService.RequestedAttribute `
+                                                                                 -RegistrationAuthority $sp.extensions.RegistrationInfo.registrationAuthority
 
     $IssuanceAuthorityRule =
 @"
@@ -160,6 +162,8 @@ function Add-ADFSTkSPRelyingPartyTrust {
                 
                 Add-ADFSRelyingPartyTrust -Identifier $entityID `
                                     -SignatureAlgorithm $SignatureAlgorithm `
+                                    -EncryptionCertificateRevocationCheck None `
+                                    -SigningCertificateRevocationCheck None `
                                     -RequestSigningCertificate $SigningCertificate `
                                     -Name $NameWithPrefix `
                                     -EncryptionCertificate $EncryptionCertificate  `

--- a/ADFSToolkit/Private/Import-ADFSTkAllTransformRules.ps1
+++ b/ADFSToolkit/Private/Import-ADFSTkAllTransformRules.ps1
@@ -127,7 +127,7 @@ function Import-ADFSTkAllTransformRules
     $TransformRules.eduPersonUniqueID = [PSCustomObject]@{
     Rule=@"
     @RuleName = "compose eduPersonUniqueID"
-    c:[Type == "urn:mace:dir:attribute-def:norEduPersonLIN" 
+    c:[Type == "urn:mace:dir:attribute-def:norEduPersonLIN"] 
      => issue(Type = "urn:oid:1.3.6.1.4.1.5923.1.1.1.13", 
      Value = RegExReplace(c.Value, "-", "") + "@$($Settings.configuration.StaticValues.schacHomeOrganization)",
      Properties["http://schemas.xmlsoap.org/ws/2005/05/identity/claimproperties/attributename"] = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri");

--- a/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
+++ b/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
@@ -30,7 +30,6 @@ param (
     $TransformRules.'transient-id' = $AllTransformRules.'transient-id'
     #$TransformRules.eduPersonTargetedID = $AllTransformRules.eduPersonTargetedID
     $TransformRules.eduPersonPrincipalName = $AllTransformRules.eduPersonPrincipalName
-    $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
     $TransformRules.mail = $AllTransformRules.mail
     $TransformRules.displayName = $AllTransformRules.displayName
     $TransformRules.givenName = $AllTransformRules.givenName
@@ -54,9 +53,9 @@ param (
         if ($RequestedAttributes.ContainsKey("urn:oid:1.3.6.1.4.1.5923.1.1.1.6")) { 
             $TransformRules.eduPersonPrincipalName = $AllTransformRules.eduPersonPrincipalName
         }
-        if ($RequestedAttributes.ContainsKey("urn:oid:1.3.6.1.4.1.5923.1.1.1.13")) { 
-            $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
-        }
+        #if ($RequestedAttributes.ContainsKey("urn:oid:1.3.6.1.4.1.5923.1.1.1.13")) { 
+        #    $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
+        #}
         if ($RequestedAttributes.ContainsKey("urn:oid:0.9.2342.19200300.100.1.3")) { 
             $TransformRules.mail = $AllTransformRules.mail
         }

--- a/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
+++ b/ADFSToolkit/Private/Import-ADFSTkIssuanceTransformRuleCategories.ps1
@@ -30,7 +30,7 @@ param (
     $TransformRules.'transient-id' = $AllTransformRules.'transient-id'
     #$TransformRules.eduPersonTargetedID = $AllTransformRules.eduPersonTargetedID
     $TransformRules.eduPersonPrincipalName = $AllTransformRules.eduPersonPrincipalName
-    #eduPersonUniqueID
+    $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
     $TransformRules.mail = $AllTransformRules.mail
     $TransformRules.displayName = $AllTransformRules.displayName
     $TransformRules.givenName = $AllTransformRules.givenName
@@ -53,6 +53,9 @@ param (
         }
         if ($RequestedAttributes.ContainsKey("urn:oid:1.3.6.1.4.1.5923.1.1.1.6")) { 
             $TransformRules.eduPersonPrincipalName = $AllTransformRules.eduPersonPrincipalName
+        }
+        if ($RequestedAttributes.ContainsKey("urn:oid:1.3.6.1.4.1.5923.1.1.1.13")) { 
+            $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
         }
         if ($RequestedAttributes.ContainsKey("urn:oid:0.9.2342.19200300.100.1.3")) { 
             $TransformRules.mail = $AllTransformRules.mail
@@ -104,7 +107,7 @@ param (
     $TransformRules.'transient-id' = $AllTransformRules.'transient-id'
     #$TransformRules.eduPersonTargetedID = $AllTransformRules.eduPersonTargetedID
     $TransformRules.eduPersonPrincipalName = $AllTransformRules.eduPersonPrincipalName
-    #eduPersonUniqueID
+    $TransformRules.eduPersonUniqueID = $AllTransformRules.eduPersonUniqueID
     $TransformRules.mail = $AllTransformRules.mail
     $TransformRules.displayName = $AllTransformRules.displayName
     $TransformRules.cn = $AllTransformRules.cn

--- a/ADFSToolkit/Private/Verify-ADFSTkSigningCert.ps1
+++ b/ADFSToolkit/Private/Verify-ADFSTkSigningCert.ps1
@@ -30,7 +30,7 @@ param (
         $signCertificateHashCompare = $Settings.configuration.signCertFingerprint -replace ":"
     }
     
-    Write-ADFSTkLog "Comparing aggregate certificate hash of: $signCertificateHash.Hash to $signCertificateHashCompare" -EntryType Information
+    Write-ADFSTkLog "Comparing aggregate certificate hash of: $($signCertificateHash.Hash) to $signCertificateHashCompare" -EntryType Information
 
     return ($signCertificateHash.Hash -eq $signCertificateHashCompare)
     


### PR DESCRIPTION
Fixed a couple of bugs, added eduPersonUniqueID to the entity categories that should have it and changed so all new RP:s doesn't do any revocation checks on encryption and signing certificates.

We must provide a small script (could be a one-liner) to fix all current RP:s or do that in the update-procedure. Otherwise the local hash cache file has to be deleted and the script will update all RP:s.