### PR TITLE
If only one attribute from Active Directory -> no Store rule

### DIFF
--- a/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
+++ b/ADFSToolkit/Private/Get-ADFSTkIssuanceTransformRules.ps1
@@ -151,7 +151,7 @@ if ($AttributesFromStore.Count)
         if ($store.name -eq "Active Directory")
         {
             $currentStoreAttributes = $AttributesFromStore.Values | ? store -eq $store.name
-            if ($currentStoreAttributes.Count -gt 0)
+            if ($currentStoreAttributes.Count -ne $null)
             {
                 $FirstRule += @"
 


### PR DESCRIPTION
If there's only one attribute that needs to be fetched from Active Directory the Store rule (Get Attributes from AD)  will not be created.