### PR TITLE
Bump to RC8 with improved fingerprinting of the toolkit via user-agent header

### DIFF
--- a/ADFSToolkit/ADFSToolkit.psd1
+++ b/ADFSToolkit/ADFSToolkit.psd1
@@ -5,7 +5,7 @@
 #
 # Generated on: 11/24/2017
 # v1.0.0.0  on: 04/17/2018
-#
+# v2.0.0    on: 12/17/2020
 #
 
 @{
@@ -29,7 +29,7 @@ Author = 'Chris Phillips, Johan Peterson and Tommy Larsson'
 CompanyName = 'CANARIE and SWAMID'
 
 # Copyright statement for this module
-Copyright = '(c) 2017 Chris Phillips CANARIE, Johan Peterson and Tommy Larsson SWAMID http://www.apache.org/licenses/LICENSE-2.0'
+Copyright = '(c) 2017-2020 Chris Phillips CANARIE, Johan Peterson and Tommy Larsson SWAMID http://www.apache.org/licenses/LICENSE-2.0'
 
 # Description of the functionality provided by this module
 Description = 'Module to handle SAML2 federation aggregates.'
@@ -112,7 +112,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        Prerelease = 'RC7'
+        Prerelease = 'RC8'
 
     } # End of PSData hashtable
 

--- a/ADFSToolkit/Private/Get-ADFSTkMetadata.ps1
+++ b/ADFSToolkit/Private/Get-ADFSTkMetadata.ps1
@@ -49,7 +49,7 @@ param (
             Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText importDownloadingFromTo -f $metadataURL, $CachedMetadataFile) -EntryType Information
                
             $webClient = New-Object System.Net.WebClient 
-            $webClient.Headers.Add("user-agent", "ADFSToolkit")
+            $webClient.Headers.Add("user-agent", "ADFSToolkit-v2")
             $webClient.DownloadFile($metadataURL, $CachedMetadataFile)
                 
             Write-ADFSTkVerboseLog (Get-ADFSTkLanguageText importSuccesfullyDownloadedMetadataFrom -f $metadataURL) -EntryType Information


### PR DESCRIPTION
- [x] updated some dates
- [x] updated to RC8
- [x] updated  user-agent to 'ADFSToolkit-v2' for easier version identification